### PR TITLE
Fix org README logo URL

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,5 @@
 
-![distroless logo](distroless-logo.svg)
+![distroless logo](https://github.com/distroless/.github/raw/main/profile/distroless-logo.svg)
 
 A distroless image contains only an application and its runtime dependencies; that is, it is a minimal image without a shell or package manager.
 


### PR DESCRIPTION
Fix the readme logo URL 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>